### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 rsnapshot (1.4.3-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Remove obsolete field Name from debian/upstream/metadata (already
+    present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 14 Jan 2020 05:56:53 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rsnapshot (1.4.3-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 14 Jan 2020 05:56:53 +0000
+
 rsnapshot (1.4.3-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 12), debhelper-compat (= 12)
 Build-Depends-Indep: openssh-client | ssh-client, rsync, lvm2, udev
 Standards-Version: 4.4.1.2
 Rules-Requires-Root: no
-Homepage: http://www.rsnapshot.org/
+Homepage: https://www.rsnapshot.org/
 Vcs-Browser: https://github.com/Debian/rsnapshot
 Vcs-Git: https://github.com/Debian/rsnapshot.git
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,6 +1,5 @@
 Bug-Database: https://github.com/rsnapshot/rsnapshot/issues
 Bug-Submit: https://github.com/rsnapshot/rsnapshot/issues/new
 Changelog: https://github.com/rsnapshot/rsnapshot/blob/master/ChangeLog
-Name: rsnapshot
 Repository: https://github.com/rsnapshot/rsnapshot.git
 Repository-Browse: https://github.com/rsnapshot/rsnapshot


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/rsnapshot/366ecddc-e701-4920-881b-a3439b0176e5.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.rsnapshot.org/-] {+https&#8203;://www.rsnapshot.org/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/366ecddc-e701-4920-881b-a3439b0176e5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/366ecddc-e701-4920-881b-a3439b0176e5/diffoscope)).
